### PR TITLE
ci: pin Node 22 for astro build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,6 +30,11 @@ jobs:
       - name: Update submodules to latest
         run: git submodule update --remote --recursive
 
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:


### PR DESCRIPTION
Astro requires Node >=22.12.0. The runner defaults to Node 20, breaking the v3 build. Adds an actions/setup-node@v4 step before bun install.